### PR TITLE
Correctly install scheduler and executor methods

### DIFF
--- a/pesos/executor.py
+++ b/pesos/executor.py
@@ -194,6 +194,7 @@ class ExecutorProcess(ProtobufProcess):
       log.info('Recovery timeout exceeded, shutting down.')
       self.shutdown(self.pid, None)
 
+  @Process.install('send_status_update')
   def send_status_update(self, status):
     if status.state is mesos.TASK_STAGING:
       log.error('Executor is not allowed to send TASK_STAGING, aborting!')
@@ -223,6 +224,7 @@ class ExecutorProcess(ProtobufProcess):
     self.updates[update.uuid] = update
     self.send(self.slave, message)
 
+  @Process.install('send_framework_message')
   def send_framework_message(self, data):
     message = mesos.internal.ExecutorToFrameworkMessage()
     message.slave_id.value = self.slave_id

--- a/pesos/executor.py
+++ b/pesos/executor.py
@@ -130,10 +130,10 @@ class ExecutorProcess(ProtobufProcess):
     ack_uuid = uuid.UUID(bytes=message.uuid)
 
     log.info(
-      'Executor received status update acknowledgement %s for task %s of framework %s',
-      ack_uuid,
-      message.task_id.value,
-      message.framework_id.value
+        'Executor received status update acknowledgement %s for task %s of framework %s',
+        ack_uuid,
+        message.task_id.value,
+        message.framework_id.value
     )
 
     if not self.updates.pop(ack_uuid, None):
@@ -204,9 +204,9 @@ class ExecutorProcess(ProtobufProcess):
       return
 
     update = mesos.internal.StatusUpdate(
-      status=status,
-      timestamp=time.time(),
-      uuid=uuid.uuid4().get_bytes()
+        status=status,
+        timestamp=time.time(),
+        uuid=uuid.uuid4().get_bytes()
     )
 
     update.framework_id.value = self.framework_id
@@ -216,8 +216,8 @@ class ExecutorProcess(ProtobufProcess):
     update.status.slave_id.value = self.slave_id
 
     message = mesos.internal.StatusUpdateMessage(
-      update=update,
-      pid=str(self.pid)
+        update=update,
+        pid=str(self.pid)
     )
 
     self.updates[update.uuid] = update

--- a/pesos/scheduler.py
+++ b/pesos/scheduler.py
@@ -1,9 +1,7 @@
 from collections import defaultdict
-from getpass import getuser
 import functools
 import logging
 import threading
-import socket
 import sys
 
 from .detector import StandaloneMasterDetector


### PR DESCRIPTION
- Since we're using `self.context.dispatch` when a user calls one of the methods on the driver, we need to now properly install the methods.
- Few cleanups around indentation
