### PR TITLE
Maintain and use offer/slave PID state

### DIFF
--- a/pesos/scheduler.py
+++ b/pesos/scheduler.py
@@ -321,6 +321,19 @@ class SchedulerProcess(ProtobufProcess):
       field = message.offer_ids.add()
       field.value = offer_id
 
+      for task in tasks:
+        if offer_id in self.saved_offers:
+          if len(self.saved_offers[offer_id.value][task.slave_id.value]) > 0:
+            self.saved_slaves[task.slave_id.value] = \
+                self.saved_offers[offer_id.value][task.slave_id.value]
+          else:
+            log.warning("Attempting to launch task %s with the wrong slave %s",
+                        task.task_id.value, task.slave_id.value)
+        else:
+          log.warning("Attempting to launch task %s with an unknown offer %s",
+                      task.task_id.value, offer_id.value)
+      self.saved_offers.pop(offer_id.value)
+
     self.send(self.master, message)
 
   @ignore_if_disconnected
@@ -334,13 +347,21 @@ class SchedulerProcess(ProtobufProcess):
     assert executor_id is not None
     assert slave_id is not None
     assert data is not None
+
+    try:
+      pid = self.saved_slaves[slave_id]
+    except KeyError:
+      pid = self.master
+      log.warning("Cannot send directly to slave %s, sending through master",
+                  slave_id)
+
     message = internal.FrameworkToExecutorMessage(
         framework_id=self.framework.id,
         executor_id=executor_id,
         slave_id=slave_id,
         data=data,
     )
-    self.send(self.master, message)
+    self.send(pid, message)
 
   @ignore_if_disconnected
   def reconcile_tasks(self, statuses):

--- a/pesos/scheduler.py
+++ b/pesos/scheduler.py
@@ -322,7 +322,7 @@ class SchedulerProcess(ProtobufProcess):
       field.value = offer_id
 
       for task in tasks:
-        if offer_id in self.saved_offers:
+        if offer_id.value in self.saved_offers:
           if len(self.saved_offers[offer_id.value][task.slave_id.value]) > 0:
             self.saved_slaves[task.slave_id.value] = \
                 self.saved_offers[offer_id.value][task.slave_id.value]

--- a/pesos/scheduler.py
+++ b/pesos/scheduler.py
@@ -323,7 +323,7 @@ class SchedulerProcess(ProtobufProcess):
 
       for task in tasks:
         if offer_id.value in self.saved_offers:
-          if len(self.saved_offers[offer_id.value][task.slave_id.value]) > 0:
+          if task.slave_id.value in self.saved_offers[offer_id.value]:
             self.saved_slaves[task.slave_id.value] = \
                 self.saved_offers[offer_id.value][task.slave_id.value]
           else:


### PR DESCRIPTION
I've replicated the same behaviour as the C++ scheduler implementation here which means the following;
- Offers, Slaves and their PIDs are stored in memory until tasks are launched
- Framework messages are sent to slaves where possible
- Rescinded offers are removed from the in-memory map
